### PR TITLE
link against boost_system-mt

### DIFF
--- a/luawt-dev-1.rockspec
+++ b/luawt-dev-1.rockspec
@@ -33,6 +33,7 @@ build = {
             libraries = {
                 "wt",
                 "wthttp",
+                "boost_system-mt",
             },
             incdirs = {
                 "src", -- for boost-xtime.hpp
@@ -46,6 +47,7 @@ build = {
                     libraries = {
                         "wt",
                         "wthttp",
+                        "boost_system-mt",
                         "stdc++"
                     },
                 },


### PR DESCRIPTION
When building shared versiob of luawt with [MXE](http://mxe.cc/)

```
/usr/lib/mxe/usr/bin/i686-w64-mingw32.shared-gcc -shared -o luawt.dll -L/usr/lib/mxe/usr/i686-w64-mingw32.shared/lib src/luawt/init.obj src/luawt/WServer.obj src/luawt/sh
ared.obj -lwt -lwthttp -lstdc++ -llua
src/luawt/shared.obj:shared.cpp:(.text$_ZN5boost16thread_exceptionC2EiPKc[__ZN5boost16thread_exceptionC2EiPKc]+0x3a): undefined reference to `boost::system::system_catego
ry()'
src/luawt/shared.obj:shared.cpp:(.text.startup+0x4): undefined reference to `boost::system::generic_category()'
src/luawt/shared.obj:shared.cpp:(.text.startup+0x9): undefined reference to `boost::system::generic_category()'
src/luawt/shared.obj:shared.cpp:(.text.startup+0xe): undefined reference to `boost::system::system_category()'
collect2: error: ld returned 1 exit status

Error: Build error: Failed compiling module luawt.dll
```
