### PR TITLE
update exitless-busted generation

### DIFF
--- a/.travis/valgrind_test.sh
+++ b/.travis/valgrind_test.sh
@@ -1,7 +1,7 @@
 set -xue
 
 echo 'os.exit = function() end' > exitless-busted
-echo 'require "busted.runner"({ batch = true })' >> exitless-busted
+echo 'require "busted.runner"({ standalone = false, batch = true })' >> exitless-busted
 valgrind \
     --error-exitcode=1 \
     --leak-check=full \


### PR DESCRIPTION
Busted 2.0.rc11-0 has the following main file:

``` lua
require 'busted.runner'({ standalone = false })
```

Previous Busted versions had batch = true instead of standalone = false.

Use both of them to be compatible with both Busted versions.

See https://travis-ci.org/LuaAndC/luawt/jobs/89948037#L1312
