### PR TITLE
Busted: use --directory option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ before_script:
 
 script:
   - export LD_PRELOAD=/lib/x86_64-linux-gnu/libpthread.so.0
-  - busted --shuffle --repeat=20 spec/*
+  - busted --shuffle --repeat=20 --directory=spec
   - if [[ "$LUA" != *"luajit"* ]]; then bash .travis/valgrind_test.sh; fi
   - luarocks make CFLAGS="-O0 -g -fPIC -ftest-coverage -fprofile-arcs" LIBFLAG="-shared --coverage"
-  - busted spec/*
+  - busted --directory=spec
 
 after_success:
   - coveralls --include src

--- a/.travis/valgrind_test.sh
+++ b/.travis/valgrind_test.sh
@@ -8,5 +8,5 @@ valgrind \
     --gen-suppressions=all \
     --suppressions=.travis/valgrind_test.supp \
     lua \
-    exitless-busted --sort spec/*
+    exitless-busted --sort --directory=spec
 rm exitless-busted


### PR DESCRIPTION
We're not very happy about spec/\* workaround.
