### PR TITLE
ADD_SIGNAL: add event_for_emit agrument

### DIFF
--- a/src/luawt/WPushButton.cpp
+++ b/src/luawt/WPushButton.cpp
@@ -45,7 +45,7 @@ int luawt_WPushButton_isDefault(lua_State* L) {
     return 1;
 }
 
-ADD_SIGNAL(clicked, WPushButton)
+ADD_SIGNAL(clicked, WPushButton, WMouseEvent)
 
 static const luaL_Reg luawt_WPushButton_methods[] = {
     METHOD(WPushButton, setText),

--- a/src/luawt/globals.hpp
+++ b/src/luawt/globals.hpp
@@ -312,10 +312,10 @@ private:
     widget_type* widget = luawt_checkFromLua<widget_type>(L, -1); \
     lua_pop(L, 1);
 
-#define CREATE_EMIT_SIGNAL_FUNC(signal, widget_type) \
+#define CREATE_EMIT_SIGNAL_FUNC(signal, widget_type, event_for_emit) \
     int luawt_##widget_type##_emit_##signal(lua_State* L) { \
         GET_WIDGET(widget_type) \
-        widget->signal().emit(WMouseEvent()); \
+        widget->signal().emit(event_for_emit()); \
         return 0; \
     }
 
@@ -337,8 +337,8 @@ private:
         return 1; \
     }
 
-#define ADD_SIGNAL(signal, widget_type) \
-    CREATE_EMIT_SIGNAL_FUNC(signal, widget_type) \
+#define ADD_SIGNAL(signal, widget_type, event_for_emit) \
+    CREATE_EMIT_SIGNAL_FUNC(signal, widget_type, event_for_emit) \
     CREATE_CONNECT_SIGNAL_FUNC(signal, widget_type) \
     CREATE_SIGNAL_FUNC(signal, widget_type)
 


### PR DESCRIPTION
Emit() method takes argument which has the same type as template
parameter of the given signal. It isn't possible to calculate it
so we have to add this arg.