### PR TITLE
automate_bindings.py: fix bug in findCorrespondingKeyInDict()

### DIFF
--- a/tools/automate_bindings.py
+++ b/tools/automate_bindings.py
@@ -389,6 +389,8 @@ def getSelf(module_name):
     return frame % (module_name, module_name)
 
 def findCorrespondingKeyInDict(dictionary, full_key):
+    if full_key in dictionary:
+        return full_key
     for key in dictionary:
         if key in full_key:
             return key


### PR DESCRIPTION
In case of specific types (e.g. `enums`) the full key may contain
index key by accident (e.g. `WPaintedDevice` <--> `int`).
Anyway, we're able to prevent it, because if key's specific, it's
stored as exactly the same in dict, hence we can just check
if this key exists before searching for partial matching.